### PR TITLE
Fix typos in Go and Python examples

### DIFF
--- a/Go/simple_file_upload/app.go
+++ b/Go/simple_file_upload/app.go
@@ -139,6 +139,6 @@ func main() {
 	// upload file contents
 	uploadFile(createResp.UploadURL, *filePathPtr)
 
-	log.Println("Succesfully uploaded file")
-	log.Println("View it here: " + "https:drive.tekcloud.com/#/f/" + createResp.File.ID)
+	log.Println("Successfully uploaded file")
+	log.Println("View it here: " + "https://drive.tekcloud.com/#/f/" + createResp.File.ID)
 }

--- a/Python/multipart_file_upload/run.py
+++ b/Python/multipart_file_upload/run.py
@@ -178,6 +178,6 @@ def main(*args, file: str) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("file", help="The file to be upload")
+    parser.add_argument("file", help="The file to be uploaded")
     args = parser.parse_args()
     main(**args.__dict__)

--- a/Python/simple_file_upload/run.py
+++ b/Python/simple_file_upload/run.py
@@ -57,13 +57,13 @@ def main(*args, file_path: str, name: str) -> None:
     create_response = create_file_record(name)
     upload(create_response["uploadUrl"], file_path)
 
-    print("File succesfully uploaded")
+    print("File successfully uploaded")
     print(f"View it here: https://drive.tekcloud.com/#/f/{create_response['file']['id']}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("file_path", help="The file to be upload")
+    parser.add_argument("file_path", help="The file to be uploaded")
     parser.add_argument("--name", help="Filename override", default="test-simple-file-upload")
     args = parser.parse_args()
     main(**args.__dict__)


### PR DESCRIPTION
Fixed a few typos I noticed in the example code:

- "Succesfully" → "Successfully" (Go and Python)
- "The file to be upload" → "The file to be uploaded" (Python)
- Fixed malformed URL "https:drive.tekcloud.com" → "https://drive.tekcloud.com" (Go)